### PR TITLE
Feature/scene scopes and entry points

### DIFF
--- a/Assets/Package/Runtime/DI/ApplicationRuntimeRegistryAttribute.cs
+++ b/Assets/Package/Runtime/DI/ApplicationRuntimeRegistryAttribute.cs
@@ -18,10 +18,11 @@ namespace SnakeCore.DI
         /// Registered types with this attribute.
         /// </summary>
         public IEnumerable<Type> RegisteredTypes => m_registeredTypes;
-        private List<Type> m_registeredTypes = new();
+        private readonly List<Type> m_registeredTypes = new();
         
         public LifetimeType LifetimeType => m_lifetimeType;
-        private LifetimeType m_lifetimeType;
+        private readonly LifetimeType m_lifetimeType;
+        
 
         /// <summary>
         /// Attribute is used to register types in the application runtime. lifetimeType is specifies

--- a/Assets/Package/Runtime/DI/EntryPointRegistryAttribute.cs
+++ b/Assets/Package/Runtime/DI/EntryPointRegistryAttribute.cs
@@ -1,0 +1,18 @@
+﻿namespace SnakeCore.DI
+{
+    /// <summary>
+    /// If defined with one of the other dependency injection attributes, the class will be registered as an entry point
+    /// will automatically be created by the DI container. Entry points are lifecycle hooks that are called when the
+    /// unity's lifecycle events are triggered. For example, <see cref="IStartable"/> will be called when the scope
+    /// is first created.
+    /// <see cref="https://vcontainer.hadashikick.jp/integrations/entrypoint">
+    ///     VContainer documentation for all entry point interfaces.
+    /// </see>
+    /// <see cref="ApplicationRuntimeRegistryAttribute"/>
+    /// <see cref="SceneRuntimeRegistryAttribute"/>
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class EntryPointRegistryAttribute : System.Attribute
+    {
+    }
+}

--- a/Assets/Package/Runtime/DI/EntryPointRegistryAttribute.cs.meta
+++ b/Assets/Package/Runtime/DI/EntryPointRegistryAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f4252d7bb20a44e69311eac966529bef
+timeCreated: 1721914309

--- a/Assets/Package/Runtime/DI/Runtime.cs
+++ b/Assets/Package/Runtime/DI/Runtime.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using SnakeCore.Config;
+using SnakeCore.DI.ConfigConditions;
+using SnakeCore.Logging;
+using SnakeCore.Reflection;
+using SnakeCore.Serialization;
+using SnakeCore.Serialization.JsonSerialization;
+using UnityEngine;
+using VContainer;
+using VContainer.Unity;
+
+namespace SnakeCore.DI
+{
+    public abstract class Runtime : LifetimeScope
+    {
+        internal static string AdditionalConfigData;
+        
+        protected IConfigValueProvider ConfigValueProvider;
+        
+        protected override void Configure(IContainerBuilder builder)
+        {
+            RegisterConfigManager(builder);
+            EntryPointsBuilder.EnsureDispatcherRegistered(builder);
+            var registrationInfos = GetRegistrationInfos();
+            
+            
+            foreach (var info in registrationInfos)
+            {
+                if (info.IsEntryPoint)
+                {
+                    var entryPointInterfaces = info.EntryPointInterfaces.ToList();
+                    if (info.SelfRegistration)
+                    {
+                        entryPointInterfaces.Add(info.Target);
+                        builder.Register(info.Target, info.Lifetime).As(entryPointInterfaces.ToArray());
+                        continue;
+                    }
+                    builder.Register(info.Target, info.Lifetime).As(entryPointInterfaces.ToArray());
+                    
+                }
+                else if (info.SelfRegistration)
+                {
+                    builder.Register(info.Target, info.Lifetime).AsSelf();
+                    continue;
+                }
+                
+                builder.Register(info.Target, info.Lifetime).As(info.RegistrationTypes.ToArray());
+            }
+        }
+        
+        private void RegisterConfigManager(IContainerBuilder builder)
+        {
+            IniConfigDeserializer configDeserializer = new IniConfigDeserializer();
+            ISerializationContext serializationContext = new SerializationContext();
+            IJsonSerializer jsonSerializer = new NewtonsoftJsonSerializer(serializationContext);
+            IParsingProvider parsingProvider = new ParsingProvider(jsonSerializer);
+            IniConfigValueProvider configValueProvider = new IniConfigValueProvider(parsingProvider, configDeserializer);
+
+            if (!string.IsNullOrEmpty(AdditionalConfigData))
+            {
+                configValueProvider.AppendConfig(AdditionalConfigData);
+            }
+            
+            builder.RegisterInstance(configDeserializer).As<IConfigDeserializer>();
+            builder.RegisterInstance(configValueProvider).As<IConfigValueProvider>();
+            builder.RegisterInstance(serializationContext).As<ISerializationContext>();
+            builder.RegisterInstance(jsonSerializer).As<IJsonSerializer>();
+            builder.RegisterInstance(parsingProvider).As<IParsingProvider>();
+            ConfigValueProvider = configValueProvider;
+        }
+
+        protected abstract IEnumerable<RegistrationInfo> GetRegistrationInfos();
+        
+
+        protected bool DoesCoverConfigConditions(MemberInfo type)
+        {
+            var attributes = type.GetCustomAttributes();
+            bool metConditions = true;
+            foreach (var attribute in attributes)
+            {
+                if (attribute is ConfigConditionAttribute configCondition)
+                {
+                    metConditions &= configCondition.Evaluate(ConfigValueProvider);
+                }
+            }
+            return metConditions;
+        }
+    }
+}

--- a/Assets/Package/Runtime/DI/Runtime.cs.meta
+++ b/Assets/Package/Runtime/DI/Runtime.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bb05be72532e40448f5234e41cbc5274
+timeCreated: 1721911385

--- a/Assets/Package/Runtime/DI/SceneRuntimeRegistryAttribute.cs
+++ b/Assets/Package/Runtime/DI/SceneRuntimeRegistryAttribute.cs
@@ -1,0 +1,28 @@
+﻿// ==============================License==================================
+// MIT License
+// Author: Taha Mert Gökdemir
+// =======================================================================
+
+using System;
+using System.Collections.Generic;
+
+namespace SnakeCore.DI
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public class SceneRuntimeRegistryAttribute : Attribute
+    {
+        public string SceneName { get; private set; }
+        
+        /// <summary>
+        /// Registered types with this attribute.
+        /// </summary>
+        public IEnumerable<Type> RegisteredTypes => m_registeredTypes;
+        private readonly List<Type> m_registeredTypes = new();
+        
+        public SceneRuntimeRegistryAttribute(string sceneName, params Type [] interfaces)
+        {
+            SceneName = sceneName;
+            m_registeredTypes.AddRange(interfaces);
+        }
+    }
+}

--- a/Assets/Package/Runtime/DI/SceneRuntimeRegistryAttribute.cs.meta
+++ b/Assets/Package/Runtime/DI/SceneRuntimeRegistryAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 220c3471f84b439e890e9b451834c70e
+timeCreated: 1721911092

--- a/Assets/Package/Runtime/DI/SnakeCoreSceneRuntime.cs
+++ b/Assets/Package/Runtime/DI/SnakeCoreSceneRuntime.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using SnakeCore.Reflection;
+using UnityEngine;
+using VContainer;
+
+namespace SnakeCore.DI
+{
+    /// <summary>
+    /// SnakeCoreSceneRuntime allow creating scene-based DI containers. This class is responsible for registering
+    /// the types that are decorated with <see cref="SceneRuntimeRegistryAttribute"/>. Types that are registered with
+    /// scene runtime registry attribute will still have access to the types that are registered with the
+    /// <see cref="SnakeCoreApplicationRuntime"/> using <see cref="ApplicationRuntimeRegistryAttribute"/>
+    /// For adding entry points to the scene runtime, use <see cref="EntryPointRegistryAttribute"/>.
+    /// </summary>
+    [DefaultExecutionOrder(-4990)]
+    public class SnakeCoreSceneRuntime : Runtime
+    {
+        private static Dictionary<string, SnakeCoreSceneRuntime> s_sceneRuntimes = new();
+        
+        private static void RegisterSceneRuntime(string sceneName, SnakeCoreSceneRuntime runtime)
+        {
+            if(s_sceneRuntimes.ContainsKey(sceneName))
+            {
+                SnakeCoreApplicationRuntime.LogWarning($"Multiple SceneRuntimes are registered for the scene {sceneName}. " +
+                                                       $"This is not allowed.");
+                Destroy(runtime);
+                return;
+            }
+            
+            s_sceneRuntimes.Add(sceneName, runtime);
+        }
+        
+        private static void UnregisterSceneRuntime(string sceneName)
+        {
+            if(s_sceneRuntimes.ContainsKey(sceneName))
+            {
+                s_sceneRuntimes.Remove(sceneName);
+            }
+        }
+        
+        protected override void Awake()
+        {
+            if (SnakeCoreApplicationRuntime.Instance == null)
+            {
+                throw new InvalidOperationException("SnakeCoreApplicationRuntime is not initialized.");
+            }
+            RegisterSceneRuntime(gameObject.scene.name, this);
+            EnqueueParent(SnakeCoreApplicationRuntime.Instance);
+            base.Awake();
+        }
+        
+        protected override void OnDestroy()
+        {
+            UnregisterSceneRuntime(gameObject.scene.name);
+            base.OnDestroy();
+        }
+        
+        protected override IEnumerable<RegistrationInfo> GetRegistrationInfos()
+        {
+            var decoratedTypes 
+                = TypeUtility.GetTypes(ShouldBeRegistered);
+            
+            var registrationInfos = new List<RegistrationInfo>();
+
+            foreach (var type in decoratedTypes)
+            {
+                if(!DoesCoverConfigConditions(type)) continue;
+                var attribute = type.GetCustomAttribute<SceneRuntimeRegistryAttribute>();
+                var isEntryPoint = type.IsDefined(typeof(EntryPointRegistryAttribute), true);
+                var info = new RegistrationInfo(type, Lifetime.Scoped, isEntryPoint, attribute.RegisteredTypes?.ToArray());
+                registrationInfos.Add(info);
+            }
+            
+            return registrationInfos;
+        }
+        
+        private bool ShouldBeRegistered(Type type)
+        {
+            SceneRuntimeRegistryAttribute attribute = type.GetCustomAttribute<SceneRuntimeRegistryAttribute>(false);
+            if(attribute == null) return false;
+            string sceneName = gameObject.scene.name;
+            return attribute.SceneName != null && string.Equals(attribute.SceneName, sceneName);
+        }
+    }
+}

--- a/Assets/Package/Runtime/DI/SnakeCoreSceneRuntime.cs.meta
+++ b/Assets/Package/Runtime/DI/SnakeCoreSceneRuntime.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d33b1cde97fb4d3cafa9f06c7c541059
+timeCreated: 1721912244

--- a/Assets/Package/package.json
+++ b/Assets/Package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.snakelikecoding.snakecore",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "displayName": "SnakeCore",
     "description": "The package that includes core functionality like concurrency and dependency injection.",
     "unity": "2021.3",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.2.0] - 2024-07-30
+### Added
+- Scene Scope has been implemented. Scene Scope is a scope that is 
+created for each scene and is destroyed when the scene is destroyed.
+- EntryPoints are now supported. EntryPoints allow access to Unity's lifecycle events.
 
 ## [1.1.0] - 2024-07-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿
 
 
-![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)
 ![Unity](https://img.shields.io/badge/Unity-2022.3.4f1-black.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 


### PR DESCRIPTION
## [1.2.0] - 2024-07-30
### Added
- Scene Scope has been implemented. Scene Scope is a scope that is 
created for each scene and is destroyed when the scene is destroyed.
- EntryPoints are now supported. EntryPoints allow access to Unity's lifecycle events.