### PR TITLE
the bug is fixed

### DIFF
--- a/Assets/Package/Runtime/DI/InjectableMonoBehaviour.cs
+++ b/Assets/Package/Runtime/DI/InjectableMonoBehaviour.cs
@@ -11,7 +11,16 @@ namespace SnakeCore.DI
     {
         protected virtual void Awake()
         {
-            SnakeCoreApplicationRuntime.Instance.Container.Inject(this);
+            var sceneRuntime = SnakeCoreSceneRuntime.GetSceneRuntime(gameObject.scene.name);
+            if(sceneRuntime != null)
+            {
+                sceneRuntime.Container.Inject(this);
+            }
+            else
+            {
+                SnakeCoreApplicationRuntime.Instance.Container.Inject(this);
+            }
+            
         }
     }
 }

--- a/Assets/Package/Runtime/DI/SnakeCoreSceneRuntime.cs
+++ b/Assets/Package/Runtime/DI/SnakeCoreSceneRuntime.cs
@@ -41,6 +41,15 @@ namespace SnakeCore.DI
             }
         }
         
+        internal static SnakeCoreSceneRuntime GetSceneRuntime(string sceneName)
+        {
+            if(s_sceneRuntimes.TryGetValue(sceneName, out var runtime))
+            {
+                return runtime;
+            }
+
+            return null;
+        }
         protected override void Awake()
         {
             if (SnakeCoreApplicationRuntime.Instance == null)

--- a/Assets/Package/Runtime/ObjectPool/GameObjectPool.cs
+++ b/Assets/Package/Runtime/ObjectPool/GameObjectPool.cs
@@ -123,6 +123,33 @@ namespace SnakeCore.ObjectPool
             return result;
         }
         
+        public T GetObject(Vector3 position, Quaternion? rotation = null)
+        {
+            if(m_objectInPoolCount == 0)
+            {
+                CreateBatch(m_batchSize);
+            }
+
+            T result;
+            lock (m_lockObject)
+            {
+                result = m_objects.FirstOrDefault(e => e.IsActive != true);
+                if (result != null)
+                {
+                    result.transform.position = position;
+                    if (rotation != null)
+                    {
+                        result.transform.rotation = rotation.Value;
+                    }
+                    
+                }
+
+                TryActivateObject(result);
+            }
+            
+            return result;
+        }
+        
         public void ReturnObject(IPoolableObject obj)
         {
             if(obj == null) throw new ArgumentNullException(nameof(obj), "Argument cannot be null.");

--- a/Assets/Package/package.json
+++ b/Assets/Package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.snakelikecoding.snakecore",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "displayName": "SnakeCore",
     "description": "The package that includes core functionality like concurrency and dependency injection.",
     "unity": "2021.3",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.1] - 2024-08-01
+### Added
+- Dependency injection bug is fixed on InjectableMonoBehaviour.
+- GameObjectPool now has a method overload that allows retrieving a 
+GameObject on a specific position and rotation.
+
 ## [1.2.0] - 2024-07-30
 ### Added
 - Scene Scope has been implemented. Scene Scope is a scope that is 


### PR DESCRIPTION
## [1.2.1] - 2024-08-01
### Added
- Dependency injection bug is fixed on InjectableMonoBehaviour.
- GameObjectPool now has a method overload that allows retrieving a 
GameObject on a specific position and rotation.